### PR TITLE
Add Intel Operators to RHODS Sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 ##################################
 
 .PHONY: setup
-setup: setup-rhods setup-sandbox
+setup: setup-rhods setup-intel setup-sandbox
 
 
 ##################################
@@ -25,6 +25,12 @@ setup-rhods:
 
 ##################################
 
+.PHONY: setup-intel
+setup-intel:
+	./setup-intel.sh
+
+##################################
+
 .PHONY: setup-sandbox
 setup-sandbox:
 	./setup-sandbox.sh
@@ -32,7 +38,13 @@ setup-sandbox:
 ##################################
 
 .PHONY: cleanup
-cleanup: cleanup-rhods cleanup-sandbox
+cleanup: cleanup-intel cleanup-rhods cleanup-sandbox
+
+##################################
+
+.PHONY: cleanup-intel
+cleanup-intel:
+	./cleanup-intel.sh
 
 ##################################
 

--- a/cleanup-intel.sh
+++ b/cleanup-intel.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+echo "Make sure you are logged in as cluster admin"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+OPENVINO_NOTEBOOK=$(oc get Notebook -n redhat-ods-applications -o name)
+echo "deleting Openvino Notebook resource"
+oc delete $OPENVINO_NOTEBOOK -n redhat-ods-applications
+
+OVMS_CSV=$(oc get subscription ovms-operator -n openshift-operators -o go-template='{{.status.currentCSV}}')
+echo "deleting sub ovms-operator"
+echo "deleting csv ${OVMS_CSV}"
+oc delete subscription ovms-operator -n openshift-operators
+oc delete clusterserviceversion ${OVMS_CSV} -n openshift-operators
+
+AIKIT_CONTAINER_NAME=$(oc get AIKitContainer -n redhat-ods-applications -o name)
+echo "deleteing AIKit Container resource"
+oc delete $AIKIT_CONTAINER_NAME -n redhat-ods-applications
+
+AIKIT_CSV=$(oc get subscription aikit-operator -n openshift-operators -o json)
+echo "deleting sub aikit-operator"
+echo "deleting csv ${AIKIT_CSV}"
+oc delete subscription aikit-operator -n openshift-operators
+oc delete clusterserviceversion ${AIKIT_CSV} -n openshift-operators

--- a/intel/AIKitContainer-resource.yaml
+++ b/intel/AIKitContainer-resource.yaml
@@ -1,0 +1,16 @@
+kind: AIKitContainer
+apiVersion: aikit.intel/v1alpha1
+metadata:
+  name: intel-aikit-container
+  namespace: redhat-ods-applications
+spec:
+  fullnameOverride: ''
+  imagestream:
+    name: oneapi-aikit
+    namespace: redhat-ods-applications
+    registry:
+      root: registry.connect.redhat.com
+      repo: intel
+      name: oneapi-aikit
+      version: latest
+  nameOverride: ''

--- a/intel/aikit-operator-subscription.yaml
+++ b/intel/aikit-operator-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: aikit-operator
+  namespace: openshift-operators
+spec:
+  channel: alpha
+  name: aikit-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/intel/openvino-notebook-resource.yaml
+++ b/intel/openvino-notebook-resource.yaml
@@ -1,0 +1,10 @@
+apiVersion: intel.com/v1alpha1
+kind: Notebook
+metadata:
+  name: v2022.1
+  namespace: redhat-ods-applications
+spec:
+  auto_update_image: false
+  git_ref: main
+  git_uri: 'https://github.com/openvinotoolkit/openvino_notebooks'
+  reconcile_duration_multiplier: 120

--- a/intel/ovms-operator-subscription.yaml
+++ b/intel/ovms-operator-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ovms-operator
+  namespace: openshift-operators
+spec:
+  channel: alpha
+  name: ovms-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: openvino-operator.v1.0.0

--- a/setup-intel.sh
+++ b/setup-intel.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+echo "Make sure you are logged in as cluster admin"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+oc apply -f "${DIR}/intel/aikit-operator-subscription.yaml"
+oc apply -f "${DIR}/intel/ovms-operator-subscription.yaml"
+
+echo "Waiting for 60s to allow operators to install"
+oc wait csv/aikit-operator.v2021.2.102120 -n openshift-operators --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
+oc wait csv/openvino-operator.v1.0.0 -n openshift-operators --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
+
+oc apply -f "${DIR}/intel/AIKitContainer-resource.yaml"
+oc apply -f "${DIR}/intel/openvino-notebook-resource.yaml"


### PR DESCRIPTION
Work originally started here: https://github.com/rhods-sandbox/rhods-sandbox/pull/7 , but created a new PR due to git errors in fetching forks. 

This PR adds Intel Operators to the RHODS Sandbox as per the original PR and additionally addesses @cfchase 's comment by adding The Openvino Notebook and AIKitContainer resources as a part of the installation. 

The resources are also deleted  as a part of the cleanup script